### PR TITLE
initialize $toc_plugins

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -371,6 +371,7 @@ class admin_plugin_advanced_config extends DokuWiki_Admin_Plugin {
     if (! is_array($plugin_list)) {
       $plugin_list = array();
     }
+    $toc_plugins = array();
 
     foreach ($plugin_list as $plugin) {
 


### PR DESCRIPTION
This PR will prevent PHP warning of "Invalid argument for foreach()" when explain plugin does not installed, Fixes #7 
