### PR TITLE
Fix PHP Warning in line 42

### DIFF
--- a/admin/export.php
+++ b/admin/export.php
@@ -39,7 +39,7 @@ class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
     {
         global $INPUT;
 
-        if (!$_REQUEST['cmd']) {
+        if (!$INPUT->has('cmd')) {
             return;
         }
 


### PR DESCRIPTION
Consistently use $INPUT to avoid warnings such as:
`PHP message: PHP Warning:  Undefined array key "cmd" in /dokuwiki-test/lib/plugins/advanced/admin/export.php on line 42`