### PR TITLE
Add media selection to export utility

### DIFF
--- a/_test/NsDepthTest.php
+++ b/_test/NsDepthTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace dokuwiki\plugin\advanced\test;
+
+use DokuWikiTest;
+
+/**
+ * tests for the advanced plugin
+ *
+ * @group plugin_advanced
+ * @group plugins
+ */
+class NsDepthTest extends DokuWikiTest
+{
+    /**
+     * @return array (searchParams [ns, recursive, type], expect)
+     */
+    public function providerParams()
+    {
+        return [
+            [['', false, 'pages'], 1],
+            [['', false, 'media'], 1],
+            [['', true, 'pages'], 0],
+            [['', true, 'media'], 0],
+            [['test', false, 'pages'], 2],
+            [['test', false, 'media'], 1],
+            [['test', true, 'pages'], 0],
+            [['test', true, 'media'], 0],
+            [['test/test1/test2/test3/test4', false, 'pages'], 6],
+            [['test/test1/test2/test3/test4', false, 'media'], 1],
+            [['test/test1/test2/test3/test4', true, 'pages'], 0],
+            [['test/test1/test2/test3/test4', true, 'media'], 0],
+        ];
+    }
+
+    /**
+     * @dataProvider providerParams
+     *
+     * @param array $searchParams
+     * @param int $expect
+     * @return void
+     */
+    public function testNsDepth($searchParams, $expect)
+    {
+        $this->assertEquals($expect, \admin_plugin_advanced_export::getSearchDepth($searchParams[0], $searchParams[1], $searchParams[2]));
+    }
+}

--- a/admin/export.php
+++ b/admin/export.php
@@ -102,15 +102,17 @@ class admin_plugin_advanced_export extends AdminPlugin
 
         echo sprintf('<h3>%s</h3>', $this->getLang('exp_select_namespace'));
 
-        echo '<p><select name="ns" class="form-control">';
-        echo '<option value="">' . $this->getLang('exp_select_namespace') . '</option>';
-        echo '<option value="(root)">(root)</option>';
+        echo '<input list="plugin__advanced-ns-list" name="ns" id="plugin__advanced-ns-input" class="form-control" />';
+
+        echo '<datalist id="plugin__advanced-ns-list">';
+
+        echo '<option value="(root)"></option>';
 
         foreach ($namespaces as $namespace) {
-            echo sprintf('<option value="%s">%s</option>', $namespace['id'], $namespace['id']);
+            echo sprintf('<option value="%s"></option>', $namespace['id']);
         }
 
-        echo '</select></p>';
+        echo '</datalist>';
         echo '<p>&nbsp;</p>';
 
         echo '<input type="hidden" name="step" value="select-ns" />';
@@ -154,11 +156,19 @@ class admin_plugin_advanced_export extends AdminPlugin
     {
         global $INPUT;
         global $lang;
+        global $conf;
 
         $namespace = str_replace(':', '/', $INPUT->str('ns'));
 
         if (!$namespace) {
             msg($this->getLang('exp_no_namespace_selected'), -1);
+            $this->step_select_ns();
+            return 0;
+        }
+
+        $nsDir = $conf['datadir'] . '/' . $namespace;
+        if (!is_dir($nsDir)) {
+            msg(sprintf($this->getLang('exp_namespace_invalid'), $nsDir), -1);
             $this->step_select_ns();
             return 0;
         }
@@ -260,6 +270,12 @@ class admin_plugin_advanced_export extends AdminPlugin
 
         $pages = [];
         $media = [];
+
+        $nsDir = $conf['datadir'] . '/' . str_replace(':', '/', $INPUT->str('ns'));
+        if (!is_dir($nsDir)) {
+            msg(sprintf($this->getLang('exp_namespace_invalid'), $nsDir), -1);
+            return 0;
+        }
 
         switch ($INPUT->str('step')) {
             case 'select-ns':

--- a/admin/export.php
+++ b/admin/export.php
@@ -142,6 +142,8 @@ class admin_plugin_advanced_export extends AdminPlugin
 
         $media = [];
         if ($include_media) {
+            // search methods for pages and media have slightly different concepts of depth
+            $options['depth'] = $follow_ns ? 2 : 1;
             search($media, $conf['mediadir'], 'search_media', $options, $namespace);
         }
 
@@ -150,7 +152,6 @@ class admin_plugin_advanced_export extends AdminPlugin
 
     private function step_select_pages()
     {
-
         global $INPUT;
         global $lang;
 
@@ -211,7 +212,6 @@ class admin_plugin_advanced_export extends AdminPlugin
         /**
          * Media table
          */
-
         echo '<table class="table inline media" width="100%">';
 
         echo '<thead><tr>
@@ -291,22 +291,17 @@ class admin_plugin_advanced_export extends AdminPlugin
 
         foreach ($pages as $page) {
             $file_fullpath = wikiFN($page);
-            $parts = explode(DIRECTORY_SEPARATOR, $conf['datadir']);
-            $file_path     = str_replace($conf['datadir'], end($parts), $file_fullpath);
+            $file_path     = \helper_plugin_advanced::PAGES_DIR . str_replace($conf['datadir'], '', $file_fullpath);
             $file_content  = io_readFile($file_fullpath);
-
             $Zip->addData($file_path, $file_content);
         }
 
         foreach ($media as $file) {
             $file_fullpath = mediaFN($file);
-            $parts = explode(DIRECTORY_SEPARATOR, $conf['mediadir']);
-            $file_path     = str_replace($conf['mediadir'], end($parts), $file_fullpath);
-            $file_content  = io_readFile($file_fullpath);
-
+            $file_path     = \helper_plugin_advanced::MEDIA_DIR . str_replace($conf['mediadir'], '', $file_fullpath);
+            $file_content  = io_readFile($file_fullpath, false);
             $Zip->addData($file_path, $file_content);
         }
-
 
         header("Content-Type: application/zip");
         header("Content-Transfer-Encoding: Binary");

--- a/admin/export.php
+++ b/admin/export.php
@@ -118,8 +118,8 @@ class admin_plugin_advanced_export extends AdminPlugin
         echo '<input type="hidden" name="step" value="select-ns" />';
 
         echo '<p class="pull-right">';
-        echo sprintf('<label><input type="checkbox" name="include-sub-ns" /> %s</label> ', $this->getLang('exp_include_sub_namespaces'));
-        echo sprintf('<label><input type="checkbox" name="include-media" /> %s</label> ', $this->getLang('exp_include_media'));
+        echo sprintf('<label><input type="checkbox" name="include-sub-ns" checked /> %s</label> ', $this->getLang('exp_include_sub_namespaces'));
+        echo sprintf('<label><input type="checkbox" name="include-media" checked /> %s</label> ', $this->getLang('exp_include_media'));
         echo sprintf('<button type="submit" name="cmd[export]" class="btn btn-default">%s &rarr;</button> ', $this->getLang('exp_export_all_pages_in_namespace'));
         echo sprintf('<button type="submit" name="export[select_pages]" class="btn btn-primary primary">%s &rarr;</button> ', $this->getLang('exp_select_pages'));
         echo '</p>';

--- a/admin/export.php
+++ b/admin/export.php
@@ -129,7 +129,9 @@ class admin_plugin_advanced_export extends AdminPlugin
     {
         global $conf;
 
-        $depth = ($follow_ns ? 0 : 2);
+        // nesting depth of namespaces + 1 level deeper for pages (e.g. ns1:ns2:ns3:start has pageDepth 4)
+        $pagesDepth = count(explode(':', $ns)) + 1;
+        $depth = ($follow_ns ? 0 : $pagesDepth);
 
         if ($ns == '(root)') {
             $ns    = '';
@@ -166,7 +168,7 @@ class admin_plugin_advanced_export extends AdminPlugin
             return 0;
         }
 
-        $nsDir = $conf['datadir'] . '/' . $namespace;
+        $nsDir = $conf['datadir'] . '/' . str_replace('(root)', '', $namespace);
         if (!is_dir($nsDir)) {
             msg(sprintf($this->getLang('exp_namespace_invalid'), $nsDir), -1);
             $this->step_select_ns();

--- a/admin/export.php
+++ b/admin/export.php
@@ -145,7 +145,7 @@ class admin_plugin_advanced_export extends AdminPlugin
         $media = [];
         if ($include_media) {
             // search methods for pages and media have slightly different concepts of depth
-            $options['depth'] = $follow_ns ? 2 : 1;
+            $options['depth'] = $follow_ns ? 0 : 1;
             search($media, $conf['mediadir'], 'search_media', $options, $namespace);
         }
 

--- a/admin/export.php
+++ b/admin/export.php
@@ -1,5 +1,8 @@
 <?php
 
+use dokuwiki\Extension\AdminPlugin;
+use dokuwiki\File\MediaFile;
+
 /**
  * Dokuwiki Advanced Import/Export Plugin
  *
@@ -7,9 +10,7 @@
  * @author     Giuseppe Di Terlizzi <giuseppe.diterlizzi@gmail.com>
  */
 
-
-
-class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
+class admin_plugin_advanced_export extends AdminPlugin
 {
 
     /**
@@ -53,16 +54,11 @@ class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
             $cmd = "cmd_$cmd";
             $this->$cmd();
         }
-
     }
 
     public function html()
     {
-
-        global $INPUT;
         global $lang;
-        global $conf;
-        global $ID;
 
         $lang['toc'] = $this->getLang('menu_export');
 
@@ -80,12 +76,10 @@ class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
 
         echo '</form>';
         echo '</div>';
-
     }
 
     private function steps_dispatcher()
     {
-
         global $INPUT;
 
         $step = $INPUT->extract('export')->str('export');
@@ -95,14 +89,11 @@ class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
         }
 
         return call_user_func(array($this, "step_$step"));
-
     }
 
     private function step_select_ns()
     {
-
         global $conf;
-        global $lang;
 
         $namespaces = array();
         $options    = array();
@@ -126,15 +117,14 @@ class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
 
         echo '<p class="pull-right">';
         echo sprintf('<label><input type="checkbox" name="include-sub-ns" /> %s</label> ', $this->getLang('exp_include_sub_namespaces'));
+        echo sprintf('<label><input type="checkbox" name="include-media" /> %s</label> ', $this->getLang('exp_include_media'));
         echo sprintf('<button type="submit" name="cmd[export]" class="btn btn-default">%s &rarr;</button> ', $this->getLang('exp_export_all_pages_in_namespace'));
         echo sprintf('<button type="submit" name="export[select_pages]" class="btn btn-primary primary">%s &rarr;</button> ', $this->getLang('exp_select_pages'));
         echo '</p>';
-
     }
 
-    private function getPagesFromNamespace($ns, $follow_ns = 0)
+    private function getNamespaceContent($ns, $follow_ns = false, $include_media = false)
     {
-
         global $conf;
 
         $depth = ($follow_ns ? 0 : 2);
@@ -150,18 +140,20 @@ class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
 
         search($pages, $conf['datadir'], 'search_allpages', $options, $namespace);
 
-        return $pages;
+        $media = [];
+        if ($include_media) {
+            search($media, $conf['mediadir'], 'search_media', $options, $namespace);
+        }
 
+        return [$pages, $media];
     }
 
     private function step_select_pages()
     {
 
         global $INPUT;
-        global $conf;
         global $lang;
 
-        $pages     = array();
         $namespace = str_replace(':', '/', $INPUT->str('ns'));
 
         if (!$namespace) {
@@ -170,11 +162,14 @@ class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
             return 0;
         }
 
-        $pages = $this->getPagesFromNamespace($INPUT->str('ns'), ($INPUT->str('include-sub-ns') ? 1 : 0));
+        [$pages, $media] = $this->getNamespaceContent($INPUT->str('ns'), (bool)$INPUT->str('include-sub-ns'), (bool)$INPUT->str('include-media'));
 
         echo sprintf('<h3>%s</h3>', $this->getLang('exp_select_pages'));
         echo sprintf('<input type="hidden" value="%s" name="ns" />', $INPUT->str('ns'));
 
+        /**
+         * Pages table
+         */
         echo '<table class="table inline pages" width="100%">';
         echo '<thead>
       <tr>
@@ -188,7 +183,6 @@ class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
         echo '<tbody>';
 
         foreach ($pages as $page) {
-
             $page_id       = $page['id'];
             $page_title    = p_get_first_heading($page_id);
             $page_size     = filesize_h($page['size']);
@@ -210,7 +204,41 @@ class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
                 $create_user, $create_date,
                 $modified_user, $modified_date,
                 $page_size);
+        }
+        echo '</tbody>';
+        echo '</table>';
 
+        /**
+         * Media table
+         */
+
+        echo '<table class="table inline media" width="100%">';
+
+        echo '<thead><tr>
+        <th width="10"><input type="checkbox" class="export-all-media" title="' . $this->getLang('select_all_media') . '" /></th>
+        <th>Media</th>
+        <th>Extension</th>
+        <th>Modified</th>
+        <th>Size</th>
+      </tr></thead>';
+        echo '<tbody>';
+
+        foreach ($media as $info) {
+            $file = new MediaFile($info['id']);
+
+            echo sprintf('
+        <tr>
+          <td><input type="checkbox" name="media[%s]" class="export-page" /></td>
+          <td>%s</td>
+          <td>%s</td>
+          <td>%s</td>
+          <td>%s</td>
+        </tr>',
+            $info['id'],
+            $info['id'],
+            $file->getExtension(),
+            dformat($file->getLastModified()),
+            filesize_h($file->getFileSize()));
         }
 
         echo '</tbody>';
@@ -223,35 +251,35 @@ class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
         echo sprintf('<button type="submit" name="export[select_ns]" class="btn btn-default">&larr; %s</button> ', $lang['btn_back']);
         echo sprintf('<button type="submit" name="cmd[export]" class="btn btn-primary primary">%s &rarr;</button>', $this->getLang('btn_export'));
         echo '</p>';
-
     }
 
     private function cmd_export()
     {
-
         global $INPUT;
         global $conf;
 
-        $pages = array();
+        $pages = [];
+        $media = [];
 
         switch ($INPUT->str('step')) {
-
             case 'select-ns':
-
-                foreach ($this->getPagesFromNamespace($INPUT->str('ns'), ($INPUT->str('include-sub-ns') ? 1 : 0)) as $page) {
+                [$pageInfo, $mediaInfo] = $this->getNamespaceContent($INPUT->str('ns'), (bool)$INPUT->str('include-sub-ns'), (bool)$INPUT->str('include-media'));
+                foreach ($pageInfo as $page) {
                     $pages[] = $page['id'];
                 }
-
+                foreach ($mediaInfo as $info) {
+                    $media[] = $info['id'];
+                }
                 break;
 
             case 'select-pages':
                 $pages = array_keys($INPUT->arr('pages'));
+                $media = array_keys($INPUT->arr('media'));
                 break;
-
         }
 
-        if (!count($pages)) {
-            msg('No page selected for export!', -1);
+        if (!count($pages) && !count($media)) {
+            msg('Nothing selected for export!', -1);
             return 0;
         }
 
@@ -262,14 +290,23 @@ class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
         $Zip->create();
 
         foreach ($pages as $page) {
-
             $file_fullpath = wikiFN($page);
-            $file_path     = str_replace($conf['datadir'], '', $file_fullpath);
+            $parts = explode(DIRECTORY_SEPARATOR, $conf['datadir']);
+            $file_path     = str_replace($conf['datadir'], end($parts), $file_fullpath);
             $file_content  = io_readFile($file_fullpath);
 
             $Zip->addData($file_path, $file_content);
-
         }
+
+        foreach ($media as $file) {
+            $file_fullpath = mediaFN($file);
+            $parts = explode(DIRECTORY_SEPARATOR, $conf['mediadir']);
+            $file_path     = str_replace($conf['mediadir'], end($parts), $file_fullpath);
+            $file_content  = io_readFile($file_fullpath);
+
+            $Zip->addData($file_path, $file_content);
+        }
+
 
         header("Content-Type: application/zip");
         header("Content-Transfer-Encoding: Binary");
@@ -277,7 +314,5 @@ class admin_plugin_advanced_export extends DokuWiki_Admin_Plugin
 
         echo $Zip->getArchive();
         die();
-
     }
-
 }

--- a/helper.php
+++ b/helper.php
@@ -1,0 +1,14 @@
+<?php
+
+use dokuwiki\Extension\Plugin;
+
+/**
+ * DokuWiki Plugin advanced (Helper Component)
+ *
+ * @license GPL 2 http://www.gnu.org/licenses/gpl-2.0.html
+ */
+class helper_plugin_advanced extends Plugin
+{
+    public const MEDIA_DIR = '_media/';
+    public const PAGES_DIR = '_pages/';
+}

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -22,6 +22,7 @@ $lang['exp_export_all_pages_in_namespace'] = 'Export everything in namespace';
 $lang['exp_include_sub_namespaces']        = 'Include sub-namespaces';
 $lang['exp_include_media']                 = 'Include media';
 $lang['exp_no_namespace_selected']         = 'No namespace selected!';
+$lang['exp_namespace_invalid']             = 'Namespace %s does not exist!';
 $lang['exp_select_namespace']              = 'Select the namespace';
 $lang['exp_select_pages']                  = 'Select pages and media';
 

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -26,12 +26,12 @@ $lang['exp_select_namespace']              = 'Select the namespace';
 $lang['exp_select_pages']                  = 'Select pages and media';
 
 $lang['imp_no_page_selected']     = 'No page selected!';
-$lang['imp_overwrite_pages']      = 'Overwrite existing pages';
+$lang['imp_overwrite_pages']      = 'Overwrite existing files';
 $lang['imp_page_already_exists']  = 'Import Skipped! Wiki page already exists (%s)';
 $lang['imp_page_summary']         = 'Imported by DokuWiki Advanced Plugin';
 $lang['imp_pages_import_success'] = 'Pages imported successfully!';
-$lang['imp_select_namespace']     = 'Select the Namespace for the import';
-$lang['imp_select_pages']         = 'Select the Pages for the import';
+$lang['imp_select_namespace']     = 'Select target namespace for the import';
+$lang['imp_select_pages']         = 'Select files for the import';
 $lang['imp_upload_backup']        = 'Upload backup file';
 $lang['imp_zip_extract_error']    = 'Error during archive export';
 $lang['imp_zip_not_found']        = 'Import archive not found';

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -11,17 +11,19 @@ $lang['menu_export'] = 'Export Utility';
 $lang['menu_import'] = 'Import Utility';
 
 $lang['select_all_pages'] = 'Select all pages';
+$lang['select_all_media'] = 'Select all media';
 
 $lang['btn_export']    = "Export";
 $lang['btn_import']    = "Import";
 $lang['btn_purge_css'] = 'Purge CSS cache';
 $lang['btn_purge_js']  = 'Purge JS cache';
 
-$lang['exp_export_all_pages_in_namespace'] = 'Export all Pages in Namespace';
+$lang['exp_export_all_pages_in_namespace'] = 'Export everything in namespace';
 $lang['exp_include_sub_namespaces']        = 'Include sub-namespaces';
+$lang['exp_include_media']                 = 'Include media';
 $lang['exp_no_namespace_selected']         = 'No namespace selected!';
-$lang['exp_select_namespace']              = 'Select the Namespace';
-$lang['exp_select_pages']                  = 'Select the Pages';
+$lang['exp_select_namespace']              = 'Select the namespace';
+$lang['exp_select_pages']                  = 'Select pages and media';
 
 $lang['imp_no_page_selected']     = 'No page selected!';
 $lang['imp_overwrite_pages']      = 'Overwrite existing pages';

--- a/script.js
+++ b/script.js
@@ -9,28 +9,40 @@
 
 jQuery(document).ready(function () {
 
-    var $adv = jQuery('#plugin_advanced_config');
+    const $adv = jQuery('#plugin_advanced_config');
 
     dw_page.makeToggle('.config_default h3', '.config_default > div', -1);
     dw_page.makeToggle('.config_protected h3', '.config_protected > div', -1);
 
     $adv.find('.purge-cache').on('click', function (e) {
-        var $btn = jQuery(this);
+        const $btn = jQuery(this);
         jQuery.get(DOKU_BASE + 'lib/exe/' + $btn.data('purgeType') + '.php?purge=true').done(function () {
             alert($btn.data('purgeMsg'));
         });
     });
 
-    var $advanced_forms = jQuery('#plugin_advanced_export, #plugin_advanced_import');
+    const $advanced_forms = jQuery('#plugin_advanced_export, #plugin_advanced_import');
 
     $advanced_forms.find('.export-all-pages, .import-all-pages').on('click', function () {
 
-        var $pages = $advanced_forms.find('table.pages tbody input[type=checkbox]');
+        const $pages = $advanced_forms.find('table.pages tbody input[type=checkbox]');
 
         if (jQuery(this).prop('checked')) {
             $pages.prop('checked', true);
         } else {
             $pages.prop('checked', false);
+        }
+
+    });
+
+    $advanced_forms.find('.export-all-media, .import-all-media').on('click', function () {
+
+        const $media = $advanced_forms.find('table.media tbody input[type=checkbox]');
+
+        if (jQuery(this).prop('checked')) {
+            $media.prop('checked', true);
+        } else {
+            $media.prop('checked', false);
         }
 
     });

--- a/style.less
+++ b/style.less
@@ -19,3 +19,9 @@
         }
     }
 }
+
+#plugin_advanced_export {
+    form input#plugin__advanced-ns-input {
+        width: 30em;
+    }
+}


### PR DESCRIPTION
This PR adds basic media handling to the export and import utilities:

- the exporter has a new option to include media files
- selection of namespaces is unchanged (based only on pages, no additional search for media directories)
- to separate the two types of files, they are stored in the Zip archive in `_pages` and `_media`
- the importer can still handle older archives with only pages, without the new subdirectories

This  should also fix #11 #14 #23 