### PR TITLE
Fix PHP Undefined error on save

### DIFF
--- a/admin/config.php
+++ b/admin/config.php
@@ -183,7 +183,7 @@ class admin_plugin_advanced_config extends DokuWiki_Admin_Plugin
         $file_info = $this->getFileInfo();
 
         $file_path   = $file_info['local'];
-        $file_name   = $file_info['localName'];
+        $file_name   = $file_info['local_name'];
         $file_backup = sprintf('%s.%s.gz', $file_path, date('YmdHis'));
 
         $content_old = io_readFile($file_path);


### PR DESCRIPTION
Fix PHP Undefined error on save when PHP Display Errors directive is set to 'On'
<img width="1194" alt="image" src="https://github.com/user-attachments/assets/3dd5393d-02a6-4576-9155-ddce594cca4d" />
